### PR TITLE
Add the functionality to have different main/info page on ELM page.

### DIFF
--- a/include/themes.h
+++ b/include/themes.h
@@ -114,8 +114,10 @@ typedef struct theme
     theme_elems_t infoElemsELM;
 	
     int gameCacheCount;
-
+	int inElmPage;
+	
     theme_element_t *itemsList;
+	theme_element_t *itemsListELM;
     theme_element_t *loadingIcon;
     int loadingIconCount;
 

--- a/include/themes.h
+++ b/include/themes.h
@@ -110,14 +110,14 @@ typedef struct theme
 
     theme_elems_t mainElems;
     theme_elems_t infoElems;
-	
-	//START of OPL_DB tweaks
+    
+    //START of OPL_DB tweaks
     theme_elems_t mainElemsELM;
     theme_elems_t infoElemsELM;
-	int inElmPage;
-	theme_element_t *itemsListELM;
+    int inElmPage;
+    theme_element_t *itemsListELM;
     //END of OPL_DB tweaks
-	
+    
     int gameCacheCount;
     
     theme_element_t *itemsList;

--- a/include/themes.h
+++ b/include/themes.h
@@ -110,14 +110,14 @@ typedef struct theme
 
     theme_elems_t mainElems;
     theme_elems_t infoElems;
-	theme_elems_t mainElemsELM;
+    theme_elems_t mainElemsELM;
     theme_elems_t infoElemsELM;
-	
+    
     int gameCacheCount;
-	int inElmPage;
-	
+    int inElmPage;
+    
     theme_element_t *itemsList;
-	theme_element_t *itemsListELM;
+    theme_element_t *itemsListELM;
     theme_element_t *loadingIcon;
     int loadingIconCount;
 

--- a/include/themes.h
+++ b/include/themes.h
@@ -110,14 +110,17 @@ typedef struct theme
 
     theme_elems_t mainElems;
     theme_elems_t infoElems;
+	
+	//START of OPL_DB tweaks
     theme_elems_t mainElemsELM;
     theme_elems_t infoElemsELM;
-    
+	int inElmPage;
+	theme_element_t *itemsListELM;
+    //END of OPL_DB tweaks
+	
     int gameCacheCount;
-    int inElmPage;
     
     theme_element_t *itemsList;
-    theme_element_t *itemsListELM;
     theme_element_t *loadingIcon;
     int loadingIconCount;
 

--- a/include/themes.h
+++ b/include/themes.h
@@ -110,7 +110,9 @@ typedef struct theme
 
     theme_elems_t mainElems;
     theme_elems_t infoElems;
-
+	theme_elems_t mainElemsELM;
+    theme_elems_t infoElemsELM;
+	
     int gameCacheCount;
 
     theme_element_t *itemsList;

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -638,10 +638,11 @@ void menuHandleInputMenu()
 void menuRenderMain()
 {
     // selected_item can't be NULL here as we only allow to switch to "Main" rendering when there is at least one device activated
+	theme_element_t* elem = NULL;
 	if(selected_item->item->userdata && selected_item->item->userdata->mode == ELM_MODE){
-		theme_element_t* elem = gTheme->mainElemsELM.first;
+		elem = gTheme->mainElemsELM.first;
     }else{
-        theme_element_t* elem = gTheme->mainElems.first;
+        elem = gTheme->mainElems.first;
     }
     
     while (elem) {
@@ -715,10 +716,11 @@ void menuRenderInfo()
     _menuRequestConfig();
 
     WaitSema(menuSemaId);
+	theme_element_t* elem = NULL;
 	if(selected_item->item->userdata && selected_item->item->userdata->mode == ELM_MODE){
-		theme_element_t* elem = gTheme->infoElemsELM.first;
+		elem = gTheme->infoElemsELM.first;
     }else{
-        theme_element_t* elem = gTheme->infoElems.first;
+        elem = gTheme->infoElems.first;
     }
     
     while (elem) {

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -639,7 +639,7 @@ void menuRenderMain()
 {
     // selected_item can't be NULL here as we only allow to switch to "Main" rendering when there is at least one device activated
     //START of OPL_DB tweaks
-	theme_element_t* elem = NULL;
+    theme_element_t* elem = NULL;
     item_list_t *list = selected_item->item->userdata;
     if(list && gTheme->mainElemsELM.first && list->mode == ELM_MODE){
         elem = gTheme->mainElemsELM.first;
@@ -658,7 +658,7 @@ void menuRenderMain()
         }
         gTheme->inElmPage = 0;
     }
-	//END of OPL_DB tweaks
+    //END of OPL_DB tweaks
     
     while (elem) {
         if (elem->drawElem)
@@ -731,7 +731,7 @@ void menuRenderInfo()
     _menuRequestConfig();
 
     WaitSema(menuSemaId);
-	//START of OPL_DB tweaks
+    //START of OPL_DB tweaks
     theme_element_t* elem = NULL;
     item_list_t *list = selected_item->item->userdata;
     if(list && gTheme->infoElemsELM.first && list->mode == ELM_MODE){
@@ -739,7 +739,7 @@ void menuRenderInfo()
     }else{
         elem = gTheme->infoElems.first;
     }
-	//END of OPL_DB tweaks
+    //END of OPL_DB tweaks
     
     while (elem) {
         if (elem->drawElem)

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -642,8 +642,20 @@ void menuRenderMain()
 	item_list_t *list = selected_item->item->userdata;
 	if(list && gTheme->mainElemsELM.first && list->mode == ELM_MODE){
 		elem = gTheme->mainElemsELM.first;
+		if (gTheme->inElmPage == 0){//Switch to ELM
+			theme_element_t *tmp = gTheme->itemsListELM;
+			gTheme->itemsListELM = gTheme->itemsList;
+			gTheme->itemsList = tmp;
+		}
+		gTheme->inElmPage = 1;
     }else{
         elem = gTheme->mainElems.first;
+		if (gTheme->inElmPage == 1){//Switch to Normal
+			theme_element_t *tmp = gTheme->itemsListELM;
+			gTheme->itemsListELM = gTheme->itemsList;
+			gTheme->itemsList = tmp;
+		}
+		gTheme->inElmPage = 0;
     }
     
     while (elem) {

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -638,7 +638,8 @@ void menuHandleInputMenu()
 void menuRenderMain()
 {
     // selected_item can't be NULL here as we only allow to switch to "Main" rendering when there is at least one device activated
-    theme_element_t* elem = NULL;
+    //START of OPL_DB tweaks
+	theme_element_t* elem = NULL;
     item_list_t *list = selected_item->item->userdata;
     if(list && gTheme->mainElemsELM.first && list->mode == ELM_MODE){
         elem = gTheme->mainElemsELM.first;
@@ -657,6 +658,7 @@ void menuRenderMain()
         }
         gTheme->inElmPage = 0;
     }
+	//END of OPL_DB tweaks
     
     while (elem) {
         if (elem->drawElem)
@@ -729,6 +731,7 @@ void menuRenderInfo()
     _menuRequestConfig();
 
     WaitSema(menuSemaId);
+	//START of OPL_DB tweaks
     theme_element_t* elem = NULL;
     item_list_t *list = selected_item->item->userdata;
     if(list && gTheme->infoElemsELM.first && list->mode == ELM_MODE){
@@ -736,6 +739,7 @@ void menuRenderInfo()
     }else{
         elem = gTheme->infoElems.first;
     }
+	//END of OPL_DB tweaks
     
     while (elem) {
         if (elem->drawElem)

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -638,24 +638,24 @@ void menuHandleInputMenu()
 void menuRenderMain()
 {
     // selected_item can't be NULL here as we only allow to switch to "Main" rendering when there is at least one device activated
-	theme_element_t* elem = NULL;
-	item_list_t *list = selected_item->item->userdata;
-	if(list && gTheme->mainElemsELM.first && list->mode == ELM_MODE){
-		elem = gTheme->mainElemsELM.first;
-		if (gTheme->inElmPage == 0){//Switch to ELM
-			theme_element_t *tmp = gTheme->itemsListELM;
-			gTheme->itemsListELM = gTheme->itemsList;
-			gTheme->itemsList = tmp;
-		}
-		gTheme->inElmPage = 1;
+    theme_element_t* elem = NULL;
+    item_list_t *list = selected_item->item->userdata;
+    if(list && gTheme->mainElemsELM.first && list->mode == ELM_MODE){
+        elem = gTheme->mainElemsELM.first;
+        if (gTheme->inElmPage == 0){//Switch to ELM
+            theme_element_t *tmp = gTheme->itemsListELM;
+            gTheme->itemsListELM = gTheme->itemsList;
+            gTheme->itemsList = tmp;
+        }
+        gTheme->inElmPage = 1;
     }else{
         elem = gTheme->mainElems.first;
-		if (gTheme->inElmPage == 1){//Switch to Normal
-			theme_element_t *tmp = gTheme->itemsListELM;
-			gTheme->itemsListELM = gTheme->itemsList;
-			gTheme->itemsList = tmp;
-		}
-		gTheme->inElmPage = 0;
+        if (gTheme->inElmPage == 1){//Switch to Normal
+            theme_element_t *tmp = gTheme->itemsListELM;
+            gTheme->itemsListELM = gTheme->itemsList;
+            gTheme->itemsList = tmp;
+        }
+        gTheme->inElmPage = 0;
     }
     
     while (elem) {
@@ -729,10 +729,10 @@ void menuRenderInfo()
     _menuRequestConfig();
 
     WaitSema(menuSemaId);
-	theme_element_t* elem = NULL;
-	item_list_t *list = selected_item->item->userdata;
-	if(list && gTheme->infoElemsELM.first && list->mode == ELM_MODE){
-		elem = gTheme->infoElemsELM.first;
+    theme_element_t* elem = NULL;
+    item_list_t *list = selected_item->item->userdata;
+    if(list && gTheme->infoElemsELM.first && list->mode == ELM_MODE){
+        elem = gTheme->infoElemsELM.first;
     }else{
         elem = gTheme->infoElems.first;
     }

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -638,11 +638,12 @@ void menuHandleInputMenu()
 void menuRenderMain()
 {
     // selected_item can't be NULL here as we only allow to switch to "Main" rendering when there is at least one device activated
+	theme_element_t* elem = NULL;
 	item_list_t *list = selected_item->item->userdata;
-	if(list && list->mode == ELM_MODE){
-		theme_element_t* elem = gTheme->mainElemsELM.first;
+	if(list && gTheme->mainElemsELM.first && list->mode == ELM_MODE){
+		elem = gTheme->mainElemsELM.first;
     }else{
-        theme_element_t* elem = gTheme->mainElems.first;
+        elem = gTheme->mainElems.first;
     }
     
     while (elem) {
@@ -716,12 +717,12 @@ void menuRenderInfo()
     _menuRequestConfig();
 
     WaitSema(menuSemaId);
-
+	theme_element_t* elem = NULL;
 	item_list_t *list = selected_item->item->userdata;
-	if(list && list->mode == ELM_MODE){
-		theme_element_t* elem = gTheme->infoElemsELM.first;
+	if(list && gTheme->infoElemsELM.first && list->mode == ELM_MODE){
+		elem = gTheme->infoElemsELM.first;
     }else{
-        theme_element_t* elem = gTheme->infoElems.first;
+        elem = gTheme->infoElems.first;
     }
     
     while (elem) {

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -639,7 +639,8 @@ void menuRenderMain()
 {
     // selected_item can't be NULL here as we only allow to switch to "Main" rendering when there is at least one device activated
 	theme_element_t* elem = NULL;
-	if(selected_item->item->userdata && selected_item->item->userdata->mode == ELM_MODE){
+	item_list_t *list = selected_item->item->userdata;
+	if(list && list->mode == ELM_MODE){
 		elem = gTheme->mainElemsELM.first;
     }else{
         elem = gTheme->mainElems.first;
@@ -717,7 +718,8 @@ void menuRenderInfo()
 
     WaitSema(menuSemaId);
 	theme_element_t* elem = NULL;
-	if(selected_item->item->userdata && selected_item->item->userdata->mode == ELM_MODE){
+	item_list_t *list = selected_item->item->userdata;
+	if(list && list->mode == ELM_MODE){
 		elem = gTheme->infoElemsELM.first;
     }else{
         elem = gTheme->infoElems.first;

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -638,12 +638,11 @@ void menuHandleInputMenu()
 void menuRenderMain()
 {
     // selected_item can't be NULL here as we only allow to switch to "Main" rendering when there is at least one device activated
-	theme_element_t* elem = NULL;
 	item_list_t *list = selected_item->item->userdata;
 	if(list && list->mode == ELM_MODE){
-		elem = gTheme->mainElemsELM.first;
+		theme_element_t* elem = gTheme->mainElemsELM.first;
     }else{
-        elem = gTheme->mainElems.first;
+        theme_element_t* elem = gTheme->mainElems.first;
     }
     
     while (elem) {
@@ -717,12 +716,12 @@ void menuRenderInfo()
     _menuRequestConfig();
 
     WaitSema(menuSemaId);
-	theme_element_t* elem = NULL;
+
 	item_list_t *list = selected_item->item->userdata;
 	if(list && list->mode == ELM_MODE){
-		elem = gTheme->infoElemsELM.first;
+		theme_element_t* elem = gTheme->infoElemsELM.first;
     }else{
-        elem = gTheme->infoElems.first;
+        theme_element_t* elem = gTheme->infoElems.first;
     }
     
     while (elem) {

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -638,8 +638,12 @@ void menuHandleInputMenu()
 void menuRenderMain()
 {
     // selected_item can't be NULL here as we only allow to switch to "Main" rendering when there is at least one device activated
-    theme_element_t *elem = gTheme->mainElems.first;
-
+	if(selected_item->item->userdata && selected_item->item->userdata->mode == ELM_MODE){
+		theme_element_t* elem = gTheme->mainElemsELM.first;
+    }else{
+        theme_element_t* elem = gTheme->mainElems.first;
+    }
+    
     while (elem) {
         if (elem->drawElem)
             elem->drawElem(selected_item, selected_item->item->current, NULL, elem);
@@ -711,7 +715,12 @@ void menuRenderInfo()
     _menuRequestConfig();
 
     WaitSema(menuSemaId);
-    theme_element_t *elem = gTheme->infoElems.first;
+	if(selected_item->item->userdata && selected_item->item->userdata->mode == ELM_MODE){
+		theme_element_t* elem = gTheme->infoElemsELM.first;
+    }else{
+        theme_element_t* elem = gTheme->infoElems.first;
+    }
+    
     while (elem) {
         if (elem->drawElem)
             elem->drawElem(selected_item, selected_item->item->current, itemConfig, elem);

--- a/src/themes.c
+++ b/src/themes.c
@@ -402,11 +402,11 @@ static mutable_image_t *initMutableImage(const char *themePath, config_set_t *th
     findDuplicate(theme->mainElems.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
     findDuplicate(theme->infoElems.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
     
-	//START of OPL_DB tweaks
+    //START of OPL_DB tweaks
     findDuplicate(theme->mainElemsELM.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
     findDuplicate(theme->infoElemsELM.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
     //END of OPL_DB tweaks
-	
+    
     if (cachePattern && !mutableImage->cache) {
         if (type == ELEM_TYPE_ATTRIBUTE_IMAGE)
             mutableImage->cache = cacheInitCache(-1, themePath, 0, cachePattern, 1);
@@ -816,7 +816,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
         backgroundElem->next = theme->mainElems.first;
         theme->mainElems.first = backgroundElem;
     }
-	//START of OPL_DB tweaks
+    //START of OPL_DB tweaks
     if (theme->mainElemsELM.first != NULL && theme->mainElemsELM.first->type != ELEM_TYPE_BACKGROUND) {
         LOG("THEMES No valid background found for mainELM, add default BG_ART\n");
         theme_element_t *backgroundElem = initBasic(themePath, themeConfig, theme, "bg", ELEM_TYPE_BACKGROUND, 0, 0, ALIGN_NONE, screenWidth, screenHeight, SCALING_NONE, gDefaultCol, theme->fonts[0]);
@@ -827,7 +827,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
         backgroundElem->next = theme->mainElemsELM.first;
         theme->mainElemsELM.first = backgroundElem;
     }
-	//END of OPL_DB tweaks
+    //END of OPL_DB tweaks
 
     if (theme->infoElems.first) {
         if (theme->infoElems.first->type != ELEM_TYPE_BACKGROUND) {
@@ -855,7 +855,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
         }
     }
     //END of OPL_DB tweaks
-	
+    
     // 2. check we have a valid ItemsList element, and link its decorator to the target element
     if (theme->itemsList) {
         items_list_t *itemsList = (items_list_t *)theme->itemsList->extended;
@@ -884,7 +884,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
         theme->itemsList->next = theme->mainElems.first->next; // Position the itemsList as second element (right after the Background)
         theme->mainElems.first->next = theme->itemsList;
     }
-	//START of OPL_DB tweaks
+    //START of OPL_DB tweaks
     if (theme->itemsListELM) {
         items_list_t *itemsList = (items_list_t *)theme->itemsListELM->extended;
         if (itemsList->decorator) {
@@ -912,7 +912,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
         theme->itemsListELM->next = theme->mainElemsELM.first->next; // Position the itemsListELM as second element (right after the Background)
         theme->mainElemsELM.first->next = theme->itemsListELM;
     }
-	//END of OPL_DB tweaks
+    //END of OPL_DB tweaks
 }
 
 static int addGUIElem(const char *themePath, config_set_t *themeConfig, theme_t *theme, theme_elems_t *elems, const char *type, const char *name)
@@ -959,13 +959,13 @@ static int addGUIElem(const char *themePath, config_set_t *themeConfig, theme_t 
                     elem = initBasic(themePath, themeConfig, theme, name, ELEM_TYPE_ITEMS_LIST, 150, MENU_POS_V, ALIGN_NONE, DIM_UNDEF, DIM_UNDEF, SCALING_RATIO, theme->textColor, theme->fonts[0]);
                     initItemsList(themePath, themeConfig, theme, elem, name, NULL);
                     theme->itemsList = elem;
-				//START of OPL_DB tweaks
+                //START of OPL_DB tweaks
                 }else if (!theme->itemsListELM){
                     elem = initBasic(themePath, themeConfig, theme, name, ELEM_TYPE_ITEMS_LIST, 150, MENU_POS_V, ALIGN_NONE, DIM_UNDEF, DIM_UNDEF, SCALING_RATIO, theme->textColor, theme->fonts[0]);
                     initItemsList(themePath, themeConfig, theme, elem, name, NULL);
                     theme->itemsListELM = elem;
                 }
-				//END of OPL_DB tweaks
+                //END of OPL_DB tweaks
             } else if (!strcmp(elementsType[ELEM_TYPE_ITEM_ICON], type)) {
                 elem = initBasic(themePath, themeConfig, theme, name, ELEM_TYPE_GAME_IMAGE, 80, theme->usedHeight >> 1, ALIGN_CENTER, DIM_UNDEF, DIM_UNDEF, SCALING_RATIO, gDefaultCol, theme->fonts[0]);
                 initGameImage(themePath, themeConfig, theme, elem, name, "ICO", 20, NULL, NULL);
@@ -1153,14 +1153,14 @@ static void thmLoad(const char *themePath)
     newT->mainElems.last = NULL;
     newT->infoElems.first = NULL;
     newT->infoElems.last = NULL;
-	//START of OPL_DB tweaks
+    //START of OPL_DB tweaks
     newT->mainElemsELM.first = NULL;
     newT->mainElemsELM.last = NULL;
     newT->infoElemsELM.first = NULL;
     newT->infoElemsELM.last = NULL;
-	newT->inElmPage = 0;
-	newT->itemsListELM = NULL;
-	//END of OPL_DB tweaks
+    newT->inElmPage = 0;
+    newT->itemsListELM = NULL;
+    //END of OPL_DB tweaks
     newT->gameCacheCount = 0;
     newT->itemsList = NULL;
     newT->loadingIcon = NULL;
@@ -1213,7 +1213,7 @@ static void thmLoad(const char *themePath)
     while (addGUIElem(themePath, themeConfig, newT, &newT->infoElems, NULL, path))
         snprintf(path, sizeof(path), "info%d", i++);
     
-	//START of OPL_DB tweaks
+    //START of OPL_DB tweaks
     //Special Main ELM page
     i = 1;
     snprintf(path, sizeof(path), "mainELM0");
@@ -1226,8 +1226,8 @@ static void thmLoad(const char *themePath)
     while(addGUIElem(themePath, themeConfig, newT, &newT->infoElemsELM, NULL, path))
         snprintf(path, sizeof(path), "infoELM%d", i++);
     
-	//END of OPL_DB tweaks
-	
+    //END of OPL_DB tweaks
+    
     validateGUIElems(themePath, themeConfig, newT);
     configFree(themeConfig);
 

--- a/src/themes.c
+++ b/src/themes.c
@@ -1138,7 +1138,19 @@ static void thmLoad(const char *themePath)
     snprintf(path, sizeof(path), "info0");
     while (addGUIElem(themePath, themeConfig, newT, &newT->infoElems, NULL, path))
         snprintf(path, sizeof(path), "info%d", i++);
-
+    
+	//Special Main ELM page
+	i = 1;
+	snprintf(path, sizeof(path), "mainELM0");
+	while (addGUIElem(themePath, themeConfig, newT, &newT->mainElemsELM, NULL, path))
+		snprintf(path, sizeof(path), "mainELM%d", i++);
+	
+	//Special Info ELM page
+	i = 1;
+	snprintf(path, sizeof(path), "infoELM0");
+	while(addGUIElem(themePath, themeConfig, newT, &newT->infoElemsELM, NULL, path))
+		snprintf(path, sizeof(path), "infoELM%d", i++);
+	
     validateGUIElems(themePath, themeConfig, newT);
     configFree(themeConfig);
 

--- a/src/themes.c
+++ b/src/themes.c
@@ -401,10 +401,10 @@ static mutable_image_t *initMutableImage(const char *themePath, config_set_t *th
 
     findDuplicate(theme->mainElems.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
     findDuplicate(theme->infoElems.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
-	
-	findDuplicate(theme->mainElemsELM.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
-	findDuplicate(theme->infoElemsELM.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
-	
+    
+    findDuplicate(theme->mainElemsELM.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
+    findDuplicate(theme->infoElemsELM.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
+    
     if (cachePattern && !mutableImage->cache) {
         if (type == ELEM_TYPE_ATTRIBUTE_IMAGE)
             mutableImage->cache = cacheInitCache(-1, themePath, 0, cachePattern, 1);
@@ -814,7 +814,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
         backgroundElem->next = theme->mainElems.first;
         theme->mainElems.first = backgroundElem;
     }
-	if (theme->mainElemsELM.first != NULL && theme->mainElemsELM.first->type != ELEM_TYPE_BACKGROUND) {
+    if (theme->mainElemsELM.first != NULL && theme->mainElemsELM.first->type != ELEM_TYPE_BACKGROUND) {
         LOG("THEMES No valid background found for mainELM, add default BG_ART\n");
         theme_element_t *backgroundElem = initBasic(themePath, themeConfig, theme, "bg", ELEM_TYPE_BACKGROUND, 0, 0, ALIGN_NONE, screenWidth, screenHeight, SCALING_NONE, gDefaultCol, theme->fonts[0]);
         if (themePath)
@@ -824,7 +824,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
         backgroundElem->next = theme->mainElemsELM.first;
         theme->mainElemsELM.first = backgroundElem;
     }
-	
+
     if (theme->infoElems.first) {
         if (theme->infoElems.first->type != ELEM_TYPE_BACKGROUND) {
             LOG("THEMES No valid background found for info, add default BG_ART\n");
@@ -837,7 +837,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
             theme->infoElems.first = backgroundElem;
         }
     }
-	if (theme->infoElemsELM.first) {
+    if (theme->infoElemsELM.first) {
         if (theme->infoElemsELM.first->type != ELEM_TYPE_BACKGROUND) {
             LOG("THEMES No valid background found for info, add default BG_ART\n");
             theme_element_t *backgroundElem = initBasic(themePath, themeConfig, theme, "bg", ELEM_TYPE_BACKGROUND, 0, 0, ALIGN_NONE, screenWidth, screenHeight, SCALING_NONE, gDefaultCol, theme->fonts[0]);
@@ -878,7 +878,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
         theme->itemsList->next = theme->mainElems.first->next; // Position the itemsList as second element (right after the Background)
         theme->mainElems.first->next = theme->itemsList;
     }
-	if (theme->itemsListELM) {
+    if (theme->itemsListELM) {
         items_list_t *itemsList = (items_list_t *)theme->itemsListELM->extended;
         if (itemsList->decorator) {
             // Second pass to find the decorator
@@ -952,10 +952,10 @@ static int addGUIElem(const char *themePath, config_set_t *themeConfig, theme_t 
                     initItemsList(themePath, themeConfig, theme, elem, name, NULL);
                     theme->itemsList = elem;
                 }else if (!theme->itemsListELM){
-					elem = initBasic(themePath, themeConfig, theme, name, ELEM_TYPE_ITEMS_LIST, 150, MENU_POS_V, ALIGN_NONE, DIM_UNDEF, DIM_UNDEF, SCALING_RATIO, theme->textColor, theme->fonts[0]);
+                    elem = initBasic(themePath, themeConfig, theme, name, ELEM_TYPE_ITEMS_LIST, 150, MENU_POS_V, ALIGN_NONE, DIM_UNDEF, DIM_UNDEF, SCALING_RATIO, theme->textColor, theme->fonts[0]);
                     initItemsList(themePath, themeConfig, theme, elem, name, NULL);
-					theme->itemsListELM = elem;
-				}
+                    theme->itemsListELM = elem;
+                }
             } else if (!strcmp(elementsType[ELEM_TYPE_ITEM_ICON], type)) {
                 elem = initBasic(themePath, themeConfig, theme, name, ELEM_TYPE_GAME_IMAGE, 80, theme->usedHeight >> 1, ALIGN_CENTER, DIM_UNDEF, DIM_UNDEF, SCALING_RATIO, gDefaultCol, theme->fonts[0]);
                 initGameImage(themePath, themeConfig, theme, elem, name, "ICO", 20, NULL, NULL);
@@ -1143,14 +1143,14 @@ static void thmLoad(const char *themePath)
     newT->mainElems.last = NULL;
     newT->infoElems.first = NULL;
     newT->infoElems.last = NULL;
-	newT->mainElemsELM.first = NULL;
+    newT->mainElemsELM.first = NULL;
     newT->mainElemsELM.last = NULL;
     newT->infoElemsELM.first = NULL;
     newT->infoElemsELM.last = NULL;
     newT->gameCacheCount = 0;
-	newT->inElmPage = 0;
+    newT->inElmPage = 0;
     newT->itemsList = NULL;
-	newT->itemsListELM = NULL;
+    newT->itemsListELM = NULL;
     newT->loadingIcon = NULL;
     newT->loadingIconCount = LOAD7_ICON - LOAD0_ICON + 1;
 
@@ -1201,18 +1201,18 @@ static void thmLoad(const char *themePath)
     while (addGUIElem(themePath, themeConfig, newT, &newT->infoElems, NULL, path))
         snprintf(path, sizeof(path), "info%d", i++);
     
-	//Special Main ELM page
-	i = 1;
-	snprintf(path, sizeof(path), "mainELM0");
-	while (addGUIElem(themePath, themeConfig, newT, &newT->mainElemsELM, NULL, path))
-		snprintf(path, sizeof(path), "mainELM%d", i++);
-	
-	//Special Info ELM page
-	i = 1;
-	snprintf(path, sizeof(path), "infoELM0");
-	while(addGUIElem(themePath, themeConfig, newT, &newT->infoElemsELM, NULL, path))
-		snprintf(path, sizeof(path), "infoELM%d", i++);
-	
+    //Special Main ELM page
+    i = 1;
+    snprintf(path, sizeof(path), "mainELM0");
+    while (addGUIElem(themePath, themeConfig, newT, &newT->mainElemsELM, NULL, path))
+        snprintf(path, sizeof(path), "mainELM%d", i++);
+    
+    //Special Info ELM page
+    i = 1;
+    snprintf(path, sizeof(path), "infoELM0");
+    while(addGUIElem(themePath, themeConfig, newT, &newT->infoElemsELM, NULL, path))
+        snprintf(path, sizeof(path), "infoELM%d", i++);
+    
     validateGUIElems(themePath, themeConfig, newT);
     configFree(themeConfig);
 

--- a/src/themes.c
+++ b/src/themes.c
@@ -401,7 +401,10 @@ static mutable_image_t *initMutableImage(const char *themePath, config_set_t *th
 
     findDuplicate(theme->mainElems.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
     findDuplicate(theme->infoElems.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
-
+	
+	findDuplicate(theme->mainElemsELM.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
+	findDuplicate(theme->infoElemsELM.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
+	
     if (cachePattern && !mutableImage->cache) {
         if (type == ELEM_TYPE_ATTRIBUTE_IMAGE)
             mutableImage->cache = cacheInitCache(-1, themePath, 0, cachePattern, 1);
@@ -811,7 +814,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
         backgroundElem->next = theme->mainElems.first;
         theme->mainElems.first = backgroundElem;
     }
-	if (!theme->mainElemsELM.first || (theme->mainElemsELM.first->type != ELEM_TYPE_BACKGROUND)) {
+	if (theme->mainElemsELM.first != NULL && theme->mainElemsELM.first->type != ELEM_TYPE_BACKGROUND) {
         LOG("THEMES No valid background found for mainELM, add default BG_ART\n");
         theme_element_t *backgroundElem = initBasic(themePath, themeConfig, theme, "bg", ELEM_TYPE_BACKGROUND, 0, 0, ALIGN_NONE, screenWidth, screenHeight, SCALING_NONE, gDefaultCol, theme->fonts[0]);
         if (themePath)
@@ -895,7 +898,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
             }
             itemsList->decorator = NULL;
         }
-    } else {
+    } else if(theme->mainElemsELM.first){
         LOG("THEMES No itemsList found in ELM page, adding a default one\n");
         theme->itemsListELM = initBasic(themePath, themeConfig, theme, "il", ELEM_TYPE_ITEMS_LIST, 150, MENU_POS_V, ALIGN_NONE, DIM_UNDEF, DIM_UNDEF, SCALING_RATIO, theme->textColor, theme->fonts[0]);
         initItemsList(themePath, themeConfig, theme, theme->itemsListELM, "il", NULL);

--- a/src/themes.c
+++ b/src/themes.c
@@ -402,9 +402,11 @@ static mutable_image_t *initMutableImage(const char *themePath, config_set_t *th
     findDuplicate(theme->mainElems.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
     findDuplicate(theme->infoElems.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
     
+	//START of OPL_DB tweaks
     findDuplicate(theme->mainElemsELM.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
     findDuplicate(theme->infoElemsELM.first, cachePattern, defaultTexture, overlayTexture, mutableImage);
-    
+    //END of OPL_DB tweaks
+	
     if (cachePattern && !mutableImage->cache) {
         if (type == ELEM_TYPE_ATTRIBUTE_IMAGE)
             mutableImage->cache = cacheInitCache(-1, themePath, 0, cachePattern, 1);
@@ -814,6 +816,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
         backgroundElem->next = theme->mainElems.first;
         theme->mainElems.first = backgroundElem;
     }
+	//START of OPL_DB tweaks
     if (theme->mainElemsELM.first != NULL && theme->mainElemsELM.first->type != ELEM_TYPE_BACKGROUND) {
         LOG("THEMES No valid background found for mainELM, add default BG_ART\n");
         theme_element_t *backgroundElem = initBasic(themePath, themeConfig, theme, "bg", ELEM_TYPE_BACKGROUND, 0, 0, ALIGN_NONE, screenWidth, screenHeight, SCALING_NONE, gDefaultCol, theme->fonts[0]);
@@ -824,6 +827,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
         backgroundElem->next = theme->mainElemsELM.first;
         theme->mainElemsELM.first = backgroundElem;
     }
+	//END of OPL_DB tweaks
 
     if (theme->infoElems.first) {
         if (theme->infoElems.first->type != ELEM_TYPE_BACKGROUND) {
@@ -837,6 +841,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
             theme->infoElems.first = backgroundElem;
         }
     }
+    //START of OPL_DB tweaks
     if (theme->infoElemsELM.first) {
         if (theme->infoElemsELM.first->type != ELEM_TYPE_BACKGROUND) {
             LOG("THEMES No valid background found for info, add default BG_ART\n");
@@ -849,7 +854,8 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
             theme->infoElemsELM.first = backgroundElem;
         }
     }
-
+    //END of OPL_DB tweaks
+	
     // 2. check we have a valid ItemsList element, and link its decorator to the target element
     if (theme->itemsList) {
         items_list_t *itemsList = (items_list_t *)theme->itemsList->extended;
@@ -878,6 +884,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
         theme->itemsList->next = theme->mainElems.first->next; // Position the itemsList as second element (right after the Background)
         theme->mainElems.first->next = theme->itemsList;
     }
+	//START of OPL_DB tweaks
     if (theme->itemsListELM) {
         items_list_t *itemsList = (items_list_t *)theme->itemsListELM->extended;
         if (itemsList->decorator) {
@@ -905,6 +912,7 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
         theme->itemsListELM->next = theme->mainElemsELM.first->next; // Position the itemsListELM as second element (right after the Background)
         theme->mainElemsELM.first->next = theme->itemsListELM;
     }
+	//END of OPL_DB tweaks
 }
 
 static int addGUIElem(const char *themePath, config_set_t *themeConfig, theme_t *theme, theme_elems_t *elems, const char *type, const char *name)
@@ -951,11 +959,13 @@ static int addGUIElem(const char *themePath, config_set_t *themeConfig, theme_t 
                     elem = initBasic(themePath, themeConfig, theme, name, ELEM_TYPE_ITEMS_LIST, 150, MENU_POS_V, ALIGN_NONE, DIM_UNDEF, DIM_UNDEF, SCALING_RATIO, theme->textColor, theme->fonts[0]);
                     initItemsList(themePath, themeConfig, theme, elem, name, NULL);
                     theme->itemsList = elem;
+				//START of OPL_DB tweaks
                 }else if (!theme->itemsListELM){
                     elem = initBasic(themePath, themeConfig, theme, name, ELEM_TYPE_ITEMS_LIST, 150, MENU_POS_V, ALIGN_NONE, DIM_UNDEF, DIM_UNDEF, SCALING_RATIO, theme->textColor, theme->fonts[0]);
                     initItemsList(themePath, themeConfig, theme, elem, name, NULL);
                     theme->itemsListELM = elem;
                 }
+				//END of OPL_DB tweaks
             } else if (!strcmp(elementsType[ELEM_TYPE_ITEM_ICON], type)) {
                 elem = initBasic(themePath, themeConfig, theme, name, ELEM_TYPE_GAME_IMAGE, 80, theme->usedHeight >> 1, ALIGN_CENTER, DIM_UNDEF, DIM_UNDEF, SCALING_RATIO, gDefaultCol, theme->fonts[0]);
                 initGameImage(themePath, themeConfig, theme, elem, name, "ICO", 20, NULL, NULL);
@@ -1143,14 +1153,16 @@ static void thmLoad(const char *themePath)
     newT->mainElems.last = NULL;
     newT->infoElems.first = NULL;
     newT->infoElems.last = NULL;
+	//START of OPL_DB tweaks
     newT->mainElemsELM.first = NULL;
     newT->mainElemsELM.last = NULL;
     newT->infoElemsELM.first = NULL;
     newT->infoElemsELM.last = NULL;
+	newT->inElmPage = 0;
+	newT->itemsListELM = NULL;
+	//END of OPL_DB tweaks
     newT->gameCacheCount = 0;
-    newT->inElmPage = 0;
     newT->itemsList = NULL;
-    newT->itemsListELM = NULL;
     newT->loadingIcon = NULL;
     newT->loadingIconCount = LOAD7_ICON - LOAD0_ICON + 1;
 
@@ -1201,6 +1213,7 @@ static void thmLoad(const char *themePath)
     while (addGUIElem(themePath, themeConfig, newT, &newT->infoElems, NULL, path))
         snprintf(path, sizeof(path), "info%d", i++);
     
+	//START of OPL_DB tweaks
     //Special Main ELM page
     i = 1;
     snprintf(path, sizeof(path), "mainELM0");
@@ -1213,6 +1226,8 @@ static void thmLoad(const char *themePath)
     while(addGUIElem(themePath, themeConfig, newT, &newT->infoElemsELM, NULL, path))
         snprintf(path, sizeof(path), "infoELM%d", i++);
     
+	//END of OPL_DB tweaks
+	
     validateGUIElems(themePath, themeConfig, newT);
     configFree(themeConfig);
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
This pull requests adds the possibility to theme creators to create a totaly different main/info page just for the ELM page.
The new theme configuration keys are called mainELM#/infoELM# , they work the same way as the main#/info# ones.